### PR TITLE
CurrentIndex no longer getting reset to zero

### DIFF
--- a/Sources/AppTeamToolBox/Int+clipToRange.swift
+++ b/Sources/AppTeamToolBox/Int+clipToRange.swift
@@ -1,0 +1,49 @@
+//
+//  Int+clipToRange.swift
+//
+//
+//  Created by Max Nabokow on 2/13/23.
+//
+
+import Foundation
+
+// Set of functions that add clipToRange functionality to the Int type
+
+public extension Int {
+    /**
+     Adjusts ("clips") an integer to be within a given range (adjusts to closest integer in the range)
+     - Parameters:
+        - range: Closed range that the integer needs to be within
+     - Returns: Updated version of itself. Does not mutate `self`.
+     - Note: If `self` is already withing `range`, this function does nothing.
+     */
+    func clippedToRange(_ range: ClosedRange<Int>) -> Self {
+        var adjusted = Swift.max(self, range.lowerBound) // lower bound adjustment
+        adjusted = Swift.min(adjusted, range.upperBound) // upper bound adjustment
+        return adjusted
+    }
+
+    /**
+     Adjusts ("clips") an integer to be within a given range (adjusts to closest integer in the range).
+     - Parameters:
+        - int: inout Int to be clipped
+        - range: Closed range that the integer needs to be within
+     - Warning: Modifies the `int` parameter directly
+     - Note: If self is already withing `range`, this function does nothing.
+     - Remark: Static to the `Int` type, so call using `Int.clipToRange(...)`.
+     */
+    static func clipToRange(_ int: inout Int, range: ClosedRange<Int>) {
+        int = int.clippedToRange(range)
+    }
+
+    /**
+     Adjusts ("clips") the integer to be within a given range (adjusts to closest integer in the range)
+     - Parameters:
+        - range: Closed range that the integer needs to be within
+     - Warning: Modifies `self` directly
+     - Note: If self is already withing `range`, this function does nothing.
+     */
+    mutating func clipToRange(_ range: ClosedRange<Int>) {
+        self = self.clippedToRange(range)
+    }
+}

--- a/Sources/AppTeamToolBox/MNQueueIterator.swift
+++ b/Sources/AppTeamToolBox/MNQueueIterator.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct MNQueueIterator<Element: Identifiable> {
     // MARK: PRIVATE
     private var items: [Element]
-    private var currIndex: Int
+    private var currIndex: Int?
 
     // MARK: PUBLIC
     
@@ -20,27 +20,31 @@ public struct MNQueueIterator<Element: Identifiable> {
     }
     
     public var elements: [Element] { items }
-    public var currentIndex: Int { currIndex }
+    public var currentIndex: Int? { currIndex }
 
     public var current: Element? {
-        return items[safe: currIndex]
+        if(currIndex == nil) { return nil }
+        return items[safe: currIndex!]
     }
 
     public var count: Int { items.count }
     public var isEmpty: Bool { items.isEmpty }
 
     public mutating func prev() {
-        currIndex -= 1
+        if(currIndex == nil) { return }
+        currIndex! -= 1
         fixIndexIfNeeded()
     }
 
     public mutating func next() {
-        currIndex += 1
+        if(currIndex == nil) { return }
+        currIndex! += 1
         fixIndexIfNeeded()
     }
 
     public mutating func insertAtCurrentIndex(_ element: Element) {
-        items.insert(element, at: currIndex)
+        if(currIndex == nil) { currIndex = 0 }
+        items.insert(element, at: currIndex!)
         fixIndexIfNeeded()
     }
     
@@ -54,13 +58,14 @@ public struct MNQueueIterator<Element: Identifiable> {
         guard !items.isEmpty else { return nil }
 
         defer { fixIndexIfNeeded() }
-        return items.remove(at: currIndex)
+        if(currIndex == nil) { return nil }
+        return items.remove(at: currIndex!)
     }
     
     @discardableResult
     public mutating func removeAll() -> [Element]? {
         guard !items.isEmpty else { return nil }
-        currIndex = -1
+        currIndex! = -1
         defer { items.removeAll() }
         return items
     }
@@ -68,12 +73,12 @@ public struct MNQueueIterator<Element: Identifiable> {
     // MARK: Private Helpers
 
     private mutating func fixIndexIfNeeded() {
-        guard !items.isEmpty else { currIndex = -1; return }
-
-        if currIndex >= items.endIndex {
-            currIndex = items.endIndex - 1
-        } else if currIndex < 0 {
-            currIndex = 0
+        guard !items.isEmpty else { currIndex = nil; return }
+        if(currIndex == nil) { return }
+        if currIndex! >= items.endIndex {
+            currIndex! = items.endIndex - 1
+        } else if currIndex! < 0 {
+            currIndex! = 0
         }
     }
 }

--- a/Sources/AppTeamToolBox/MNQueueIterator.swift
+++ b/Sources/AppTeamToolBox/MNQueueIterator.swift
@@ -65,18 +65,24 @@ public struct MNQueueIterator<Element: Identifiable> {
     }
     
     @discardableResult
-    public mutating func removeAll() -> [Element]? {
-        guard !items.isEmpty else { return nil }
-        currIndex! = -1
-        defer { items.removeAll() }
-        return items
+    public mutating func removeAll() -> [Element] {
+        // Make sure items isn't empty already
+        guard !items.isEmpty else { return [] }
+        
+        let copy = items // Keep a copy of the items in the array to return later
+        
+        items.removeAll()
+        
+        fixIndexIfNeeded()
+        
+        return copy
     }
     
     // MARK: Private Helpers
 
     private mutating func fixIndexIfNeeded() {
         // Only proceed if the index was valid before
-        // If it was invalid (nil), we don't know what to fix it to
+        // If it was invalid (nil), we don't know what to fix it to, so we keep it as is
         guard currIndex != nil else { return }
         
         // Only proceed if there are items, else invalidate index since there are no elements to index into
@@ -85,10 +91,7 @@ public struct MNQueueIterator<Element: Identifiable> {
         // If we got here, there are definitely items and the index is non-nil
         // So, we adjust the index to make sure its not out of bounds
         
-        if currIndex! >= items.endIndex {
-            currIndex! = items.endIndex - 1
-        } else if currIndex! < 0 {
-            currIndex! = 0
-        }
+        let validRange = 0...items.endIndex-1
+        currIndex!.clipToRange(validRange)
     }
 }

--- a/Sources/AppTeamToolBox/MNQueueIterator.swift
+++ b/Sources/AppTeamToolBox/MNQueueIterator.swift
@@ -9,13 +9,14 @@ import Foundation
 
 public struct MNQueueIterator<Element: Identifiable> {
     // MARK: PRIVATE
+
     private var items: [Element]
     private var currIndex: Int?
 
     // MARK: PUBLIC
     
     public init(_ elements: [Element]) {
-        self.items = elements
+        items = elements
         currIndex = 0
     }
     
@@ -49,7 +50,7 @@ public struct MNQueueIterator<Element: Identifiable> {
     }
     
     public mutating func setAllItems(to elements: [Element]) {
-        self.items = elements
+        items = elements
         fixIndexIfNeeded()
     }
 
@@ -91,7 +92,7 @@ public struct MNQueueIterator<Element: Identifiable> {
         // If we got here, there are definitely items and the index is non-nil
         // So, we adjust the index to make sure its not out of bounds
         
-        let validRange = 0...items.endIndex-1
+        let validRange = 0 ... items.endIndex - 1
         currIndex!.clipToRange(validRange)
     }
 }

--- a/Sources/AppTeamToolBox/MNQueueIterator.swift
+++ b/Sources/AppTeamToolBox/MNQueueIterator.swift
@@ -14,12 +14,12 @@ public struct MNQueueIterator<Element: Identifiable> {
     private var currIndex: Int?
 
     // MARK: PUBLIC
-    
+
     public init(_ elements: [Element]) {
         items = elements
-        currIndex = 0
+        currIndex = !items.isEmpty ? 0 : nil // When there are items, set to 0, else nil
     }
-    
+
     public var elements: [Element] { items }
     public var currentIndex: Int? { currIndex }
 
@@ -34,24 +34,24 @@ public struct MNQueueIterator<Element: Identifiable> {
     public mutating func prev() {
         guard currIndex != nil else { return }
         currIndex! -= 1
-        fixIndexIfNeeded()
+        fixIndexIntoRange()
     }
 
     public mutating func next() {
         guard currIndex != nil else { return }
         currIndex! += 1
-        fixIndexIfNeeded()
+        fixIndexIntoRange()
     }
 
     public mutating func insertAtCurrentIndex(_ element: Element) {
         if currIndex == nil { currIndex = 0 }
         items.insert(element, at: currIndex!)
-        fixIndexIfNeeded()
+        fixIndexIntoRange()
     }
-    
+
     public mutating func setAllItems(to elements: [Element]) {
         items = elements
-        fixIndexIfNeeded()
+        currIndex = !items.isEmpty ? 0 : nil // When there are items, set to 0, else nil
     }
 
     @discardableResult
@@ -59,39 +59,39 @@ public struct MNQueueIterator<Element: Identifiable> {
         guard !items.isEmpty, let currIndex else { return nil }
 
         let removedItem = items.remove(at: currIndex)
-        
-        fixIndexIfNeeded() // Fix indices if currIndex is now invalid after the removal
-        
+
+        fixIndexIntoRange() // Fix indices if currIndex is now invalid after the removal
+
         return removedItem
     }
-    
+
     @discardableResult
     public mutating func removeAll() -> [Element] {
         // Make sure items isn't empty already
         guard !items.isEmpty else { return [] }
-        
+
         let copy = items // Keep a copy of the items in the array to return later
-        
+
         items.removeAll()
-        
-        fixIndexIfNeeded()
-        
+
+        fixIndexIntoRange()
+
         return copy
     }
-    
+
     // MARK: Private Helpers
 
-    private mutating func fixIndexIfNeeded() {
+    private mutating func fixIndexIntoRange() {
         // Only proceed if the index was valid before
         // If it was invalid (nil), we don't know what to fix it to, so we keep it as is
         guard currIndex != nil else { return }
-        
+
         // Only proceed if there are items, else invalidate index since there are no elements to index into
         guard !items.isEmpty else { currIndex = nil; return }
-        
+
         // If we got here, there are definitely items and the index is non-nil
         // So, we adjust the index to make sure its not out of bounds
-        
+
         let validRange = 0 ... items.endIndex - 1
         currIndex!.clipToRange(validRange)
     }

--- a/Sources/AppTeamToolBox/MNQueueIterator.swift
+++ b/Sources/AppTeamToolBox/MNQueueIterator.swift
@@ -51,8 +51,16 @@ public struct MNQueueIterator<Element: Identifiable> {
 
     public mutating func setAllItems(to elements: [Element]) {
         items = elements
-        currIndex = !items.isEmpty ? 0 : nil // When there are items, set to 0, else nil
+        
+        // If there are items and index was previously invalid, start iterating from index zero
+        if !items.isEmpty && currIndex == nil {
+            currIndex = 0
+        }
+        
+        // If the new items array has less elements than before, make sure currentIndex isn't out of bounds
+        fixIndexIntoRange()
     }
+    
 
     @discardableResult
     public mutating func removeCurrent() -> Element? {


### PR DESCRIPTION
Follow-up change to stop `currentIndex` getting reset to zero every time that `setAllItems` gets called.